### PR TITLE
fixing jacoco coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: cd dynodao-parent && mvn clean install -B -V
 matrix:
   include:
     - jdk: openjdk8
-      after_success: mvn jacoco:report -pl "org.dynodao:dynodapi-api,org.dynodao:dynodao-processor" -B && bash <(curl -s https://codecov.io/bash)
+      after_success: cd dynodao-parent && mvn jacoco:report -pl "org.dynodao:dynodapi-api,org.dynodao:dynodao-processor" -B && bash <(curl -s https://codecov.io/bash)
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: cd dynodao-parent && mvn clean install -B -V
 matrix:
   include:
     - jdk: openjdk8
-      after_success: cd dynodao-parent && mvn jacoco:report -pl "org.dynodao:dynodapi-api,org.dynodao:dynodao-processor" -B && bash <(curl -s https://codecov.io/bash)
+      after_success: mvn jacoco:report -pl "org.dynodao:dynodao-api,org.dynodao:dynodao-processor" -B && bash <(curl -s https://codecov.io/bash)
 
 cache:
   directories:


### PR DESCRIPTION
getting error
```
[INFO] Scanning for projects...
[ERROR] [ERROR] Could not find the selected project in the reactor: org.dynodao:dynodapi-api @ 
[ERROR] Could not find the selected project in the reactor: org.dynodao:dynodapi-api -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MavenExecutionException
```